### PR TITLE
Enable alternative URL (sandbox) and callback

### DIFF
--- a/libnexmo/base.py
+++ b/libnexmo/base.py
@@ -78,8 +78,6 @@ class Nexmo(object):
             Any :class:`~libnexmo.exceptions.NexmoError` subclass.
 
         """
-        assert url.startswith(API_ENDPOINT)
-        assert url.endswith('/json')
         method = method.lower()
         assert method in ['get', 'post']
 


### PR DESCRIPTION
Hello just to say that there is a currently undocumented feature of nexmo that you can append &callback=<url> to the URL

also there is a sandbox [here](https://labs.nexmo.com/) where you can sign up for a sandbox account and test callbacks etc. without paying for it.

So I had to remove these two lines.

Regards
